### PR TITLE
fix(auth): harden BFF routing and preserve internal calls

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -209,7 +209,7 @@ npm run test:coverage    # 生成覆盖率报告
 
 1. **上下文检索优先级**: 开始任务或修改代码前，优先使用 `mcp__fast_context__fast_context_search` 做语义检索；再用 `rg`/`sed`/`nl` 精确核验文件、符号和行号
 2. **不要再引用旧的 `mcp__ace-tool__search_context`**: 该仓库当前统一使用 `mcp__fast_context__fast_context_search` 作为首选上下文检索方式
-3. **Giffgaff OAuth 的 `GIFFGAFF_REDIRECT_URI` 只影响服务端 token exchange**: 前端授权跳转仍由 `src/giffgaff/js/modules/oauth-handler.js` 中的 `oauthConfig.redirectUri` 控制，Netlify 环境变量不会自动改写前端授权 URL
+3. **Giffgaff OAuth 的 `GIFFGAFF_REDIRECT_URI` 只影响服务端 token exchange**: 前端授权跳转仍由 `src/giffgaff/js/modules/api-config.js` 中的 `oauthConfig.redirectUri` 控制，Netlify 环境变量不会自动改写前端授权 URL
 4. **修改 Functions 时**: 必须通过 `withAuth` 中间件包装 handler
 5. **修改前端模块时**: 使用相对路径导入模块
 6. **添加新 Function 时**: 在 `server.js` 中注册 Express 路由 (本地开发)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -207,11 +207,14 @@ npm run test:coverage    # 生成覆盖率报告
 
 ## AI 使用指引
 
-1. **修改 Functions 时**: 必须通过 `withAuth` 中间件包装 handler
-2. **修改前端模块时**: 使用相对路径导入模块
-3. **添加新 Function 时**: 在 `server.js` 中注册 Express 路由 (本地开发)
-4. **测试变更时**: 运行 `npm test` 确保通过
-5. **部署前**: 运行 `npm run quality-check && npm run security-check`
+1. **上下文检索优先级**: 开始任务或修改代码前，优先使用 `mcp__fast_context__fast_context_search` 做语义检索；再用 `rg`/`sed`/`nl` 精确核验文件、符号和行号
+2. **不要再引用旧的 `mcp__ace-tool__search_context`**: 该仓库当前统一使用 `mcp__fast_context__fast_context_search` 作为首选上下文检索方式
+3. **Giffgaff OAuth 的 `GIFFGAFF_REDIRECT_URI` 只影响服务端 token exchange**: 前端授权跳转仍由 `src/giffgaff/js/modules/oauth-handler.js` 中的 `oauthConfig.redirectUri` 控制，Netlify 环境变量不会自动改写前端授权 URL
+4. **修改 Functions 时**: 必须通过 `withAuth` 中间件包装 handler
+5. **修改前端模块时**: 使用相对路径导入模块
+6. **添加新 Function 时**: 在 `server.js` 中注册 Express 路由 (本地开发)
+7. **测试变更时**: 运行 `npm test` 确保通过
+8. **部署前**: 运行 `npm run quality-check && npm run security-check`
 
 ---
 

--- a/env.example
+++ b/env.example
@@ -36,6 +36,10 @@ RECAPTCHA_SECRET_KEY=
 # ❌ 禁止使用默认值或简单密码
 ACCESS_KEY=
 
+# Simyo 代理客户端令牌
+# ⚠️ 启用 Simyo 代理时必填；server.js 不再提供默认回退
+SIMYO_CLIENT_TOKEN=
+
 # Giffgaff OAuth token exchange 回调 URI
 # 注意：该变量只影响服务端 token exchange；前端授权跳转 URI 仍在 src/giffgaff/js/modules/api-config.js 中配置。
 GIFFGAFF_REDIRECT_URI=giffgaff://auth/callback/

--- a/env.example
+++ b/env.example
@@ -30,11 +30,15 @@ TURNSTILE_ENFORCE=true
 RECAPTCHA_SITE_KEY=
 RECAPTCHA_SECRET_KEY=
 
-# 受保护函数访问密钥（要求调用方在 Header x-esim-key 或 body.authKey / ?authKey 携带匹配值）
+# 受保护函数访问密钥（仅允许通过 Header x-esim-key 或 x-app-key 传递）
 # ⚠️ 必填：Server 与 Functions/BFF 共享的访问密钥
 # 🔐 生成强随机密钥: openssl rand -hex 32
 # ❌ 禁止使用默认值或简单密码
 ACCESS_KEY=
+
+# Giffgaff OAuth token exchange 回调 URI
+# 注意：该变量只影响服务端 token exchange；前端授权跳转 URI 仍在 src/giffgaff/js/modules/api-config.js 中配置。
+GIFFGAFF_REDIRECT_URI=giffgaff://auth/callback/
 
 # 可选：自定义API超时时间（毫秒）
 API_TIMEOUT=30000

--- a/netlify/edge-functions/CLAUDE.md
+++ b/netlify/edge-functions/CLAUDE.md
@@ -4,7 +4,7 @@
 
 ## 模块职责
 
-作为 Backend-For-Frontend 代理层，接收前端 `/bff/*` 请求，在服务端注入 ACCESS_KEY 并转发到对应的 `/.netlify/functions/*` 目标。
+作为 Backend-For-Frontend 代理层，接收前端 `/bff/*` 请求，在服务端注入 ACCESS_KEY 并转发到显式白名单内的 `/.netlify/functions/*` 目标。
 
 ## 入口与启动
 
@@ -20,13 +20,14 @@
 前端请求 /bff/{functionName}
   -> Edge Function (bff-proxy)
     -> 注入 x-esim-key 头 (ACCESS_KEY)
+    -> 校验目标是否在白名单内
     -> 转发到 /.netlify/functions/{functionName}
     -> 透传响应
 ```
 
 ## 关键依赖与配置
 
-- **环境变量**: `ACCESS_KEY`
+- **环境变量**: `ACCESS_KEY`, `ALLOWED_ORIGIN`
 
 ## 测试与质量
 
@@ -36,7 +37,8 @@
 ## 常见问题
 
 1. **ACCESS_KEY 未配置**: 返回 500 Server Misconfigured
-2. **CORS 问题**: Edge Function 不设置 CORS 头，由 Functions 中间件处理
+2. **ALLOWED_ORIGIN 未配置或不匹配**: 返回 403 Forbidden
+3. **CORS 问题**: Edge Function 会补充 CORS 头，但最终函数侧仍会再次执行来源校验
 
 ## 相关文件清单
 

--- a/netlify/edge-functions/bff-proxy.js
+++ b/netlify/edge-functions/bff-proxy.js
@@ -77,13 +77,16 @@ export default async (request, context) => {
   const sameOrigin = requestOrigin === url.origin;
   const configuredOrigin = allowedOrigins.includes(requestOrigin);
   const corsOrigin = sameOrigin || configuredOrigin ? requestOrigin : '';
+  const allowMissingOriginForPublicGet = targetName === 'public-config' && request.method === 'GET';
+  const fallbackCorsOrigin = allowedOrigins[0] || DEFAULT_ALLOWED_ORIGIN;
+  const errorCorsHeaders = buildCorsHeaders(corsOrigin || fallbackCorsOrigin);
 
-  if (!corsOrigin) {
+  if (!corsOrigin && !allowMissingOriginForPublicGet) {
     console.warn(`[BFF] ${ts} | blocked origin=${requestOrigin || 'missing'} target=${targetName}`);
-    return jsonResponse(403, { error: 'Forbidden', message: 'Origin not allowed' });
+    return jsonResponse(403, { error: 'Forbidden', message: 'Origin not allowed' }, errorCorsHeaders);
   }
 
-  const corsHeaders = buildCorsHeaders(corsOrigin);
+  const corsHeaders = corsOrigin ? buildCorsHeaders(corsOrigin) : {};
   if (request.method === 'OPTIONS') {
     return new Response('', { status: 200, headers: corsHeaders });
   }

--- a/netlify/edge-functions/bff-proxy.js
+++ b/netlify/edge-functions/bff-proxy.js
@@ -16,6 +16,8 @@ const BFF_ROUTES = new Map([
   ['public-config', ['GET', 'OPTIONS']]
 ]);
 
+// 注意：此文件运行在 Deno（Edge Function），无法直接引用 Node.js 的 _shared/cors.js。
+// 下方 parseAllowedOrigins 逻辑需与 netlify/functions/_shared/cors.js 的 parseOrigins 保持同步。
 const DEFAULT_ALLOWED_ORIGIN = 'https://esim.cosr.eu.org';
 
 function getEnv(name, fallback = '') {

--- a/netlify/edge-functions/bff-proxy.js
+++ b/netlify/edge-functions/bff-proxy.js
@@ -2,8 +2,51 @@
  * Netlify Edge Function: BFF Proxy
  * - 接收前端对 /bff/* 的请求
  * - 在服务端附加 x-esim-key（来自环境变量 ACCESS_KEY）
- * - 转发到对应的 /.netlify/functions/* 目标
+ * - 仅转发显式允许的 /.netlify/functions/* 目标
  */
+
+const BFF_ROUTES = new Map([
+  ['giffgaff-token-exchange', ['POST', 'OPTIONS']],
+  ['giffgaff-graphql', ['POST', 'OPTIONS']],
+  ['giffgaff-mfa-challenge', ['POST', 'OPTIONS']],
+  ['giffgaff-mfa-validation', ['POST', 'OPTIONS']],
+  ['giffgaff-sms-activate', ['POST', 'OPTIONS']],
+  ['auto-activate-esim', ['POST', 'OPTIONS']],
+  ['verify-cookie', ['POST', 'OPTIONS']],
+  ['public-config', ['GET', 'OPTIONS']]
+]);
+
+const DEFAULT_ALLOWED_ORIGIN = 'https://esim.cosr.eu.org';
+
+function getEnv(name, fallback = '') {
+  return (typeof Deno !== 'undefined' && Deno.env && Deno.env.get(name)) || fallback;
+}
+
+function parseAllowedOrigins(raw) {
+  return String(raw || DEFAULT_ALLOWED_ORIGIN)
+    .split(',')
+    .map(origin => origin.trim())
+    .filter(Boolean);
+}
+
+function jsonResponse(status, body, headers = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: {
+      'Content-Type': 'application/json',
+      ...headers
+    }
+  });
+}
+
+function buildCorsHeaders(origin) {
+  return {
+    'Access-Control-Allow-Origin': origin,
+    'Access-Control-Allow-Headers': 'Content-Type, Authorization, X-MFA-Signature, X-MFA-Ref, X-MFA-Challenge-Ref, X-CF-Turnstile',
+    'Access-Control-Allow-Methods': 'POST, GET, OPTIONS',
+    'Vary': 'Origin'
+  };
+}
 
 export default async (request, context) => {
   const url = new URL(request.url);
@@ -15,8 +58,34 @@ export default async (request, context) => {
   }
 
   const targetName = url.pathname.replace(/^\/bff\//, '');
-  if (!targetName) {
-    return new Response('Bad Request', { status: 400 });
+  if (!targetName || !/^[a-z0-9-]+$/.test(targetName)) {
+    return jsonResponse(400, { error: 'Bad Request', message: 'Invalid BFF target' });
+  }
+
+  const allowedMethods = BFF_ROUTES.get(targetName);
+  if (!allowedMethods) {
+    console.warn(`[BFF] ${ts} | blocked unknown target=${targetName}`);
+    return jsonResponse(404, { error: 'Not Found', message: 'BFF target not allowed' });
+  }
+
+  if (!allowedMethods.includes(request.method)) {
+    return jsonResponse(405, { error: 'Method Not Allowed' });
+  }
+
+  const allowedOrigins = parseAllowedOrigins(getEnv('ALLOWED_ORIGIN'));
+  const requestOrigin = request.headers.get('origin') || '';
+  const sameOrigin = requestOrigin === url.origin;
+  const configuredOrigin = allowedOrigins.includes(requestOrigin);
+  const corsOrigin = sameOrigin || configuredOrigin ? requestOrigin : '';
+
+  if (!corsOrigin) {
+    console.warn(`[BFF] ${ts} | blocked origin=${requestOrigin || 'missing'} target=${targetName}`);
+    return jsonResponse(403, { error: 'Forbidden', message: 'Origin not allowed' });
+  }
+
+  const corsHeaders = buildCorsHeaders(corsOrigin);
+  if (request.method === 'OPTIONS') {
+    return new Response('', { status: 200, headers: corsHeaders });
   }
 
   console.log(`[BFF] ${ts} | ${request.method} ${url.pathname} → target=${targetName}`);
@@ -26,21 +95,17 @@ export default async (request, context) => {
 
   // 从 Edge 运行时环境读取密钥
   // Netlify Edge 使用 Deno 运行时
-  const accessKey = (typeof Deno !== 'undefined' && Deno.env && Deno.env.get('ACCESS_KEY')) || '';
+  const accessKey = getEnv('ACCESS_KEY');
   if (!accessKey) {
     console.error(`[BFF] ${ts} | ACCESS_KEY missing in Edge env`);
-    return new Response(JSON.stringify({ error: 'Server Misconfigured', message: 'ACCESS_KEY not configured' }), {
-      status: 500,
-      headers: { 'Content-Type': 'application/json' }
-    });
+    return jsonResponse(500, { error: 'Server Misconfigured', message: 'ACCESS_KEY not configured' }, corsHeaders);
   }
   console.log(`[BFF] ${ts} | ACCESS_KEY present, proceeding`);
 
-  // 复制请求头并添加服务端密钥头（仅内部互调使用，不影响浏览器 CORS）
+  // 复制请求头并添加服务端密钥头；客户端提供的内部密钥一律不透传。
   const headers = new Headers(request.headers);
-  if (accessKey) {
-    headers.set('x-esim-key', accessKey);
-  }
+  headers.delete('x-app-key');
+  headers.set('x-esim-key', accessKey);
 
   // 复制请求体
   let body = undefined;
@@ -51,10 +116,7 @@ export default async (request, context) => {
       console.log(`[BFF] ${ts} | body read OK, size=${body.byteLength} bytes`);
     } catch (bodyErr) {
       console.error(`[BFF] ${ts} | body read FAILED: ${bodyErr.message}`);
-      return new Response(JSON.stringify({ error: 'Bad Request', message: 'Failed to read request body' }), {
-        status: 400,
-        headers: { 'Content-Type': 'application/json' }
-      });
+      return jsonResponse(400, { error: 'Bad Request', message: 'Failed to read request body' }, corsHeaders);
     }
   }
 
@@ -70,15 +132,17 @@ export default async (request, context) => {
     response = await fetch(proxiedRequest);
   } catch (fetchErr) {
     console.error(`[BFF] ${ts} | fetch to Function FAILED: ${fetchErr.message}`);
-    return new Response(JSON.stringify({ error: 'Bad Gateway', message: 'Failed to reach upstream function' }), {
-      status: 502,
-      headers: { 'Content-Type': 'application/json' }
-    });
+    return jsonResponse(502, { error: 'Bad Gateway', message: 'Failed to reach upstream function' }, corsHeaders);
   }
 
   // 响应日志（不包含敏感信息）
   console.log(`[BFF] ${ts} | response from ${functionUrl.pathname}: status=${response.status} ok=${response.ok}`);
 
-  // 直接透传响应
-  return response;
+  const responseHeaders = new Headers(response.headers);
+  Object.entries(corsHeaders).forEach(([key, value]) => responseHeaders.set(key, value));
+  return new Response(response.body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers: responseHeaders
+  });
 };

--- a/netlify/functions/CLAUDE.md
+++ b/netlify/functions/CLAUDE.md
@@ -41,6 +41,11 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
 }, { validateSchema: mySchema, requireAuth: true });
 ```
 
+### 内部调用约束
+- 受保护函数的内部互调必须通过 `x-esim-key` 或 `x-app-key` 头传递内部密钥
+- `authKey` 不再允许通过 body 或 queryStringParameters 传递
+- `verify-cookie` 的失败响应语义为 `success: false, valid: false`，调用方必须以 `valid` 为准
+
 ### 验证 Schema
 ```javascript
 const schema = {
@@ -53,7 +58,7 @@ const schema = {
 - **axios**: HTTP 请求 (Functions 内部调用外部 API)
 - **cheerio**: HTML 解析 (爬虫场景)
 - **@sentry/node**: 错误监控 (生产环境)
-- **环境变量**: `ACCESS_KEY`, `GIFFGAFF_CLIENT_ID`, `GIFFGAFF_CLIENT_SECRET`, `SENTRY_DSN`
+- **环境变量**: `ACCESS_KEY`, `ALLOWED_ORIGIN`, `GIFFGAFF_CLIENT_ID`, `GIFFGAFF_CLIENT_SECRET`, `GIFFGAFF_REDIRECT_URI`, `SENTRY_DSN`
 
 ## 数据模型
 
@@ -73,10 +78,14 @@ const schema = {
 ```javascript
 {
   code: string,            // 授权码
-  code_verifier: string,   // PKVE Verifier
-  redirect_uri: string     // 回调 URL
+  code_verifier: string    // PKCE Verifier
 }
 ```
+
+### Token Exchange 行为
+- `redirect_uri` 由服务端环境变量 `GIFFGAFF_REDIRECT_URI` 固定提供
+- 前端不应再把 `redirect_uri` 传给 `/bff/giffgaff-token-exchange`
+- 若 Netlify 环境变量配置了 `GIFFGAFF_REDIRECT_URI`，只影响服务端 token exchange，不会自动改变前端授权跳转 URL
 
 ## 测试与质量
 

--- a/netlify/functions/CLAUDE.md
+++ b/netlify/functions/CLAUDE.md
@@ -58,7 +58,7 @@ const schema = {
 - **axios**: HTTP 请求 (Functions 内部调用外部 API)
 - **cheerio**: HTML 解析 (爬虫场景)
 - **@sentry/node**: 错误监控 (生产环境)
-- **环境变量**: `ACCESS_KEY`, `ALLOWED_ORIGIN`, `GIFFGAFF_CLIENT_ID`, `GIFFGAFF_CLIENT_SECRET`, `GIFFGAFF_REDIRECT_URI`, `SENTRY_DSN`
+- **环境变量**: `ACCESS_KEY`, `ALLOWED_ORIGIN`, `GIFFGAFF_CLIENT_ID`, `GIFFGAFF_CLIENT_SECRET`, `GIFFGAFF_REDIRECT_URI`, `SIMYO_CLIENT_TOKEN`, `SENTRY_DSN`
 
 ## 数据模型
 

--- a/netlify/functions/_shared/internal-headers.js
+++ b/netlify/functions/_shared/internal-headers.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const { AuthError } = require('./middleware');
+
+/**
+ * 构建内部函数互调所需的请求头
+ * - 仅通过 Header 传递内部密钥，避免 URL / Body 泄漏
+ * - 若 ACCESS_KEY 未配置则抛出 500 错误
+ */
+function getInternalHeaders() {
+  if (!process.env.ACCESS_KEY) {
+    throw new AuthError('ACCESS_KEY 未配置', 500);
+  }
+  return {
+    'Content-Type': 'application/json',
+    'x-esim-key': process.env.ACCESS_KEY
+  };
+}
+
+module.exports = { getInternalHeaders };

--- a/netlify/functions/_shared/middleware.js
+++ b/netlify/functions/_shared/middleware.js
@@ -47,19 +47,9 @@ function getProvidedKey(event) {
     Object.entries(event.headers || {}).map(([k, v]) => [k.toLowerCase(), v])
   );
 
-  // 优先级: Header > Body > Query
+  // 仅允许 Header 传递内部密钥，避免 URL / Body 泄漏
   const fromHeader = lower['x-esim-key'] || lower['x-app-key'];
   if (fromHeader) return fromHeader;
-
-  try {
-    const body = JSON.parse(event.body || '{}');
-    if (body && typeof body.authKey === 'string') {
-      return body.authKey;
-    }
-  } catch {}
-
-  const query = event.queryStringParameters || {};
-  if (query.authKey) return query.authKey;
 
   return '';
 }
@@ -75,9 +65,11 @@ function authenticate(event) {
     Object.entries(event.headers || {}).map(([k, v]) => [k.toLowerCase(), v])
   );
   const requestOrigin = lower.origin;
+  const requestMethod = event.httpMethod || 'GET';
+  const isInternalCall = lower['x-esim-key'] || lower['x-app-key'];
 
   // CORS 预检请求
-  if (event.httpMethod === 'OPTIONS') {
+  if (requestMethod === 'OPTIONS') {
     // 验证来源
     if (!isAllowedOrigin(requestOrigin)) {
       throw new AuthError('Origin not allowed', 403);
@@ -86,6 +78,10 @@ function authenticate(event) {
   }
 
   // 非预检请求：验证来源
+  if (!requestOrigin && !isInternalCall) {
+    throw new AuthError('Origin not allowed', 403);
+  }
+
   if (!isAllowedOrigin(requestOrigin)) {
     throw new AuthError('Origin not allowed', 403);
   }

--- a/netlify/functions/_shared/middleware.js
+++ b/netlify/functions/_shared/middleware.js
@@ -77,12 +77,12 @@ function authenticate(event) {
     return { preflight: true, origin: requestOrigin };
   }
 
-  // 非预检请求：验证来源
+  // 非预检请求：内部调用可跳过 Origin gate，但仍需在后续校验内部密钥
   if (!requestOrigin && !isInternalCall) {
     throw new AuthError('Origin not allowed', 403);
   }
 
-  if (!isAllowedOrigin(requestOrigin)) {
+  if (requestOrigin && !isAllowedOrigin(requestOrigin)) {
     throw new AuthError('Origin not allowed', 403);
   }
 
@@ -296,17 +296,19 @@ function withAuth(handler, options = {}) {
       // 执行业务逻辑
       const result = await handler(event, context, { auth, body: parsedBody });
 
+      const responseOrigin = auth.origin;
+
       // 确保返回正确的响应格式
       if (!result.statusCode) {
         return {
           statusCode: 200,
-          headers: createHeaders(auth.origin),
+          headers: createHeaders(responseOrigin),
           body: JSON.stringify(result)
         };
       }
 
       // 合并默认头
-      result.headers = createHeaders(auth.origin, result.headers || {});
+      result.headers = createHeaders(responseOrigin, result.headers || {});
       return result;
 
     } catch (error) {

--- a/netlify/functions/giffgaff-graphql.js
+++ b/netlify/functions/giffgaff-graphql.js
@@ -7,9 +7,12 @@ const axios = require('axios');
 const { withAuth, validateInput, AuthError } = require('./_shared/middleware');
 
 function getInternalHeaders() {
+  if (!process.env.ACCESS_KEY) {
+    throw new AuthError('ACCESS_KEY 未配置', 500);
+  }
   return {
     'Content-Type': 'application/json',
-    'x-esim-key': process.env.ACCESS_KEY || ''
+    'x-esim-key': process.env.ACCESS_KEY
   };
 }
 
@@ -194,7 +197,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
             timeout: 15000
           });
 
-          if (r.data?.success && r.data?.accessToken) {
+          if (r.data?.valid && r.data?.accessToken) {
             accessToken = r.data.accessToken;
             requestHeaders['Authorization'] = `Bearer ${accessToken}`;
             console.log(`[GGQL] ${ts} | token refreshed, retrying upstream call`);
@@ -206,7 +209,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
             console.log(`[GGQL] ${ts} | retry OK: status=${response.status}`);
             break; // 重试成功，跳出循环
           } else {
-            console.error(`[GGQL] ${ts} | cookie refresh failed: success=${r.data?.success}`);
+            console.error(`[GGQL] ${ts} | cookie refresh failed: valid=${r.data?.valid}`);
             throw err;
           }
         } catch (reErr) {

--- a/netlify/functions/giffgaff-graphql.js
+++ b/netlify/functions/giffgaff-graphql.js
@@ -6,6 +6,13 @@
 const axios = require('axios');
 const { withAuth, validateInput, AuthError } = require('./_shared/middleware');
 
+function getInternalHeaders() {
+  return {
+    'Content-Type': 'application/json',
+    'x-esim-key': process.env.ACCESS_KEY || ''
+  };
+}
+
 // 输入验证schema
 const graphqlSchema = {
   query: {
@@ -183,7 +190,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
         console.log(`[GGQL] ${ts} | attempting cookie-based token refresh`);
         try {
           const r = await axios.post(verifyCookieUrl, { cookie }, {
-            headers: { 'Content-Type': 'application/json' },
+            headers: getInternalHeaders(),
             timeout: 15000
           });
 

--- a/netlify/functions/giffgaff-graphql.js
+++ b/netlify/functions/giffgaff-graphql.js
@@ -5,16 +5,7 @@
 
 const axios = require('axios');
 const { withAuth, validateInput, AuthError } = require('./_shared/middleware');
-
-function getInternalHeaders() {
-  if (!process.env.ACCESS_KEY) {
-    throw new AuthError('ACCESS_KEY 未配置', 500);
-  }
-  return {
-    'Content-Type': 'application/json',
-    'x-esim-key': process.env.ACCESS_KEY
-  };
-}
+const { getInternalHeaders } = require('./_shared/internal-headers');
 
 // 输入验证schema
 const graphqlSchema = {

--- a/netlify/functions/giffgaff-mfa-challenge.js
+++ b/netlify/functions/giffgaff-mfa-challenge.js
@@ -7,9 +7,12 @@ const axios = require('axios');
 const { withAuth, validateInput, AuthError } = require('./_shared/middleware');
 
 function getInternalHeaders() {
+  if (!process.env.ACCESS_KEY) {
+    throw new AuthError('ACCESS_KEY 未配置', 500);
+  }
   return {
     'Content-Type': 'application/json',
-    'x-esim-key': process.env.ACCESS_KEY || ''
+    'x-esim-key': process.env.ACCESS_KEY
   };
 }
 
@@ -80,7 +83,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
           headers: getInternalHeaders(),
           timeout: 30000
         });
-        if (cookieVerifyResponse.data?.success && cookieVerifyResponse.data?.accessToken) {
+        if (cookieVerifyResponse.data?.valid && cookieVerifyResponse.data?.accessToken) {
           accessToken = cookieVerifyResponse.data.accessToken;
         }
       } catch (cookieError) {
@@ -185,7 +188,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
           timeout: 30000
         });
 
-        if (cookieVerifyResponse.data?.success && cookieVerifyResponse.data?.accessToken) {
+        if (cookieVerifyResponse.data?.valid && cookieVerifyResponse.data?.accessToken) {
           let refreshed = cookieVerifyResponse.data.accessToken;
           const looksLikeJwt = typeof refreshed === 'string' && refreshed.includes('.') && refreshed.length > 200;
 

--- a/netlify/functions/giffgaff-mfa-challenge.js
+++ b/netlify/functions/giffgaff-mfa-challenge.js
@@ -5,16 +5,7 @@
 
 const axios = require('axios');
 const { withAuth, validateInput, AuthError } = require('./_shared/middleware');
-
-function getInternalHeaders() {
-  if (!process.env.ACCESS_KEY) {
-    throw new AuthError('ACCESS_KEY 未配置', 500);
-  }
-  return {
-    'Content-Type': 'application/json',
-    'x-esim-key': process.env.ACCESS_KEY
-  };
-}
+const { getInternalHeaders } = require('./_shared/internal-headers');
 
 // 输入验证schema
 const mfaChallengeSchema = {

--- a/netlify/functions/giffgaff-mfa-challenge.js
+++ b/netlify/functions/giffgaff-mfa-challenge.js
@@ -6,6 +6,13 @@
 const axios = require('axios');
 const { withAuth, validateInput, AuthError } = require('./_shared/middleware');
 
+function getInternalHeaders() {
+  return {
+    'Content-Type': 'application/json',
+    'x-esim-key': process.env.ACCESS_KEY || ''
+  };
+}
+
 // 输入验证schema
 const mfaChallengeSchema = {
   source: {
@@ -70,7 +77,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
     if (!accessToken) {
       try {
         const cookieVerifyResponse = await axios.post(verifyCookieUrl, { cookie: mergedCookie }, {
-          headers: { 'Content-Type': 'application/json' },
+          headers: getInternalHeaders(),
           timeout: 30000
         });
         if (cookieVerifyResponse.data?.success && cookieVerifyResponse.data?.accessToken) {
@@ -174,7 +181,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
     if (isExpired && mergedCookie) {
       try {
         const cookieVerifyResponse = await axios.post(verifyCookieUrl, { cookie: mergedCookie }, {
-          headers: { 'Content-Type': 'application/json' },
+          headers: getInternalHeaders(),
           timeout: 30000
         });
 

--- a/netlify/functions/giffgaff-mfa-validation.js
+++ b/netlify/functions/giffgaff-mfa-validation.js
@@ -6,6 +6,13 @@
 const axios = require('axios');
 const { withAuth, validateInput, AuthError } = require('./_shared/middleware');
 
+function getInternalHeaders() {
+  return {
+    'Content-Type': 'application/json',
+    'x-esim-key': process.env.ACCESS_KEY || ''
+  };
+}
+
 // 输入验证schema
 const mfaValidationSchema = {
   ref: {
@@ -50,7 +57,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
   if (cookie && !accessToken) {
     try {
       const cookieVerifyResponse = await axios.post(verifyCookieUrl, { cookie }, {
-        headers: { 'Content-Type': 'application/json' },
+        headers: getInternalHeaders(),
         timeout: 30000
       });
 
@@ -94,7 +101,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
     if (isExpired && cookie) {
       try {
         const cookieVerifyResponse = await axios.post(verifyCookieUrl, { cookie }, {
-          headers: { 'Content-Type': 'application/json' },
+          headers: getInternalHeaders(),
           timeout: 30000
         });
 

--- a/netlify/functions/giffgaff-mfa-validation.js
+++ b/netlify/functions/giffgaff-mfa-validation.js
@@ -7,9 +7,12 @@ const axios = require('axios');
 const { withAuth, validateInput, AuthError } = require('./_shared/middleware');
 
 function getInternalHeaders() {
+  if (!process.env.ACCESS_KEY) {
+    throw new AuthError('ACCESS_KEY 未配置', 500);
+  }
   return {
     'Content-Type': 'application/json',
-    'x-esim-key': process.env.ACCESS_KEY || ''
+    'x-esim-key': process.env.ACCESS_KEY
   };
 }
 
@@ -61,7 +64,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
         timeout: 30000
       });
 
-      if (cookieVerifyResponse.data?.success && cookieVerifyResponse.data?.accessToken) {
+      if (cookieVerifyResponse.data?.valid && cookieVerifyResponse.data?.accessToken) {
         accessToken = cookieVerifyResponse.data.accessToken;
       }
     } catch (cookieError) {
@@ -105,7 +108,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
           timeout: 30000
         });
 
-        if (cookieVerifyResponse.data?.success && cookieVerifyResponse.data?.accessToken) {
+        if (cookieVerifyResponse.data?.valid && cookieVerifyResponse.data?.accessToken) {
           const refreshed = cookieVerifyResponse.data.accessToken;
           response = await sendValidation(refreshed);
         } else {

--- a/netlify/functions/giffgaff-mfa-validation.js
+++ b/netlify/functions/giffgaff-mfa-validation.js
@@ -5,16 +5,7 @@
 
 const axios = require('axios');
 const { withAuth, validateInput, AuthError } = require('./_shared/middleware');
-
-function getInternalHeaders() {
-  if (!process.env.ACCESS_KEY) {
-    throw new AuthError('ACCESS_KEY 未配置', 500);
-  }
-  return {
-    'Content-Type': 'application/json',
-    'x-esim-key': process.env.ACCESS_KEY
-  };
-}
+const { getInternalHeaders } = require('./_shared/internal-headers');
 
 // 输入验证schema
 const mfaValidationSchema = {

--- a/netlify/functions/giffgaff-token-exchange.js
+++ b/netlify/functions/giffgaff-token-exchange.js
@@ -46,11 +46,6 @@ const tokenExchangeSchema = {
     minLength: 43,
     maxLength: 128,
     pattern: /^[A-Za-z0-9\-._~]+$/
-  },
-  redirect_uri: {
-    required: false,
-    type: 'string',
-    maxLength: 500
   }
 };
 
@@ -58,7 +53,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
   // 输入验证
   validateInput(tokenExchangeSchema, body);
 
-  const { code, code_verifier: codeVerifier, redirect_uri: redirectUri } = body;
+  const { code, code_verifier: codeVerifier } = body;
 
   // 验证环境配置
   const { clientId, clientSecret } = validateClientCredentials();
@@ -72,7 +67,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
   const form = new URLSearchParams({
     grant_type: 'authorization_code',
     code,
-    redirect_uri: redirectUri || defaultRedirectUri,
+    redirect_uri: defaultRedirectUri,
     code_verifier: codeVerifier
   });
 

--- a/netlify/functions/verify-cookie.js
+++ b/netlify/functions/verify-cookie.js
@@ -74,7 +74,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
   return {
     statusCode: 200,
     body: JSON.stringify({
-      success: true,
+      success: false,
       valid: false,
       accessToken: null,
       emailSignature: null,

--- a/netlify/functions/verify-cookie.js
+++ b/netlify/functions/verify-cookie.js
@@ -38,12 +38,16 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
   // 验证Cookie并获取Access Token
   const result = await validateCookieAndGetToken(cookie);
 
+  // success: Cookie 验证请求本身是否成功（HTTP 层面）
+  // valid:   Cookie 是否可用于后续 API 调用（需同时拿到可用的 JWT 令牌）
+  // 调用方（前端 & 内部函数）应以 valid 字段作为能否继续的唯一判断依据。
   if (result.success) {
     const looksLikeJwt = typeof result.accessToken === 'string' &&
                          result.accessToken.includes('.') &&
                          result.accessToken.length > 200;
 
-    // 只有拿到疑似 JWT 的令牌才视为可直接进入第2步
+    // Cookie 验证通过但未拿到可用 JWT → success=true, valid=false
+    // 表示服务可达、Cookie 有效，但缺少可用于 API 的令牌（需走 OAuth 或补充会话）
     if (!looksLikeJwt) {
       return {
         statusCode: 200,
@@ -58,6 +62,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
       };
     }
 
+    // Cookie 验证通过且拿到可用 JWT → success=true, valid=true
     return {
       statusCode: 200,
       body: JSON.stringify({
@@ -71,6 +76,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
     };
   }
 
+  // Cookie 验证失败 → success=false, valid=false
   return {
     statusCode: 200,
     body: JSON.stringify({
@@ -78,7 +84,7 @@ exports.handler = withAuth(async (event, context, { auth, body }) => {
       valid: false,
       accessToken: null,
       emailSignature: null,
-      message: result.error || '无法��Cookie获取访问令牌'
+      message: result.error || '无法通过Cookie获取访问令牌'
     })
   };
 }, {

--- a/server.js
+++ b/server.js
@@ -29,7 +29,6 @@ const { parseOrigins, isAllowedOrigin: _isAllowedOrigin, resolveCorsOrigin: _res
 const origins = parseOrigins(process.env.ALLOWED_ORIGIN);
 const isAllowedOrigin = (origin) => _isAllowedOrigin(origin, origins);
 const getCorsOrigin = (origin) => _resolveCorsOrigin(origin, origins);
-const DEFAULT_SIMYO_CLIENT_TOKEN = 'e77b7e2f43db41bb95b17a2a11581a38';
 const DEFAULT_SIMYO_CLIENT_PLATFORM = 'ios';
 const DEFAULT_SIMYO_CLIENT_VERSION = '4.23.5';
 const DEFAULT_SIMYO_USER_AGENT = 'MijnSimyoFT/4.23.5 (iOS 26.3; iPhone16,1)';
@@ -103,6 +102,7 @@ const giffgaffGraphql = require('./netlify/functions/giffgaff-graphql');
 const giffgaffTokenExchange = require('./netlify/functions/giffgaff-token-exchange');
 const verifyCookie = require('./netlify/functions/verify-cookie');
 const giffgaffSmsActivate = require('./netlify/functions/giffgaff-sms-activate');
+const autoActivateEsim = require('./netlify/functions/auto-activate-esim');
 const publicConfig = require('./netlify/functions/public-config');
 
 // 包装Netlify Functions为Express路由
@@ -156,8 +156,11 @@ const functionRoutes = [
   ['giffgaff-token-exchange', giffgaffTokenExchange],
   ['verify-cookie', verifyCookie],
   ['giffgaff-sms-activate', giffgaffSmsActivate],
+  ['auto-activate-esim', autoActivateEsim],
   ['public-config', publicConfig]
 ];
+app.locals.bffRoutes = functionRoutes.map(([name]) => `/bff/${name}`);
+app.locals.functionRoutes = functionRoutes.map(([name]) => `/.netlify/functions/${name}`);
 functionRoutes.forEach(([name, handler]) => {
   const wrapped = wrapNetlifyFunction(handler);
   app.use(`/.netlify/functions/${name}`, wrapped);
@@ -190,9 +193,9 @@ app.use('/api/simyo/*', (req, res) => {
         headers: {
             'Content-Type': 'application/json',
             'User-Agent': req.headers['user-agent'] || process.env.SIMYO_USER_AGENT || DEFAULT_SIMYO_USER_AGENT,
-            'X-Client-Token': req.headers['x-client-token'] || process.env.SIMYO_CLIENT_TOKEN || DEFAULT_SIMYO_CLIENT_TOKEN,
-            'X-Client-Platform': req.headers['x-client-platform'] || process.env.SIMYO_CLIENT_PLATFORM || DEFAULT_SIMYO_CLIENT_PLATFORM,
-            'X-Client-Version': req.headers['x-client-version'] || process.env.SIMYO_CLIENT_VERSION || DEFAULT_SIMYO_CLIENT_VERSION,
+            'X-Client-Token': process.env.SIMYO_CLIENT_TOKEN || '',
+            'X-Client-Platform': process.env.SIMYO_CLIENT_PLATFORM || DEFAULT_SIMYO_CLIENT_PLATFORM,
+            'X-Client-Version': process.env.SIMYO_CLIENT_VERSION || DEFAULT_SIMYO_CLIENT_VERSION,
             ...(req.headers['x-session-token'] ? { 'X-Session-Token': req.headers['x-session-token'] } : {})
         },
         timeout: 30000
@@ -257,13 +260,15 @@ app.use((req, res) => {
     });
 });
 
-// 启动服务器
-app.listen(PORT, () => {
-    Logger.log(`🚀 eSIM工具服务器已启动`);
-    Logger.log(`📍 本地地址: http://localhost:${PORT}`);
-    Logger.log(`🔧 Giffgaff工具: http://localhost:${PORT}/giffgaff`);
-    Logger.log(`📱 Simyo工具: http://localhost:${PORT}/simyo`);
-    Logger.log(`🌐 环境: ${process.env.NODE_ENV || 'development'}`);
-});
+// 启动服务器。被测试或其他模块 require 时不自动占用端口。
+if (require.main === module) {
+    app.listen(PORT, () => {
+        Logger.log(`🚀 eSIM工具服务器已启动`);
+        Logger.log(`📍 本地地址: http://localhost:${PORT}`);
+        Logger.log(`🔧 Giffgaff工具: http://localhost:${PORT}/giffgaff`);
+        Logger.log(`📱 Simyo工具: http://localhost:${PORT}/simyo`);
+        Logger.log(`🌐 环境: ${process.env.NODE_ENV || 'development'}`);
+    });
+}
 
 module.exports = app;

--- a/server.js
+++ b/server.js
@@ -185,6 +185,14 @@ app.use('/api/simyo/*', (req, res) => {
         return res.status(200).end();
     }
 
+    const simyoClientToken = process.env.SIMYO_CLIENT_TOKEN;
+    if (!simyoClientToken) {
+        return res.status(500).json({
+            error: 'Server Misconfigured',
+            message: 'SIMYO_CLIENT_TOKEN 未配置'
+        });
+    }
+
     // 代理请求
     const axios = require('axios');
     const config = {
@@ -193,7 +201,7 @@ app.use('/api/simyo/*', (req, res) => {
         headers: {
             'Content-Type': 'application/json',
             'User-Agent': req.headers['user-agent'] || process.env.SIMYO_USER_AGENT || DEFAULT_SIMYO_USER_AGENT,
-            'X-Client-Token': process.env.SIMYO_CLIENT_TOKEN || '',
+            'X-Client-Token': simyoClientToken,
             'X-Client-Platform': process.env.SIMYO_CLIENT_PLATFORM || DEFAULT_SIMYO_CLIENT_PLATFORM,
             'X-Client-Version': process.env.SIMYO_CLIENT_VERSION || DEFAULT_SIMYO_CLIENT_VERSION,
             ...(req.headers['x-session-token'] ? { 'X-Session-Token': req.headers['x-session-token'] } : {})

--- a/src/giffgaff/js/modules/cookie-handler.js
+++ b/src/giffgaff/js/modules/cookie-handler.js
@@ -39,11 +39,10 @@ export class CookieHandler {
                                 result.accessToken.length > 200;
 
             if (result.valid && looksLikeJwt) {
-                // 保存访问令牌和Cookie
+                // Cookie 验证通过且拿到可用 JWT → 完全成功
                 stateManager.set('accessToken', result.accessToken);
                 stateManager.saveCookie(cookie);
 
-                // 启动有效性监控
                 this.startValidityMonitor();
 
                 return {
@@ -51,13 +50,15 @@ export class CookieHandler {
                     accessToken: result.accessToken,
                     message: t('giffgaff.cookie.verifySuccess')
                 };
-            } else if (!result.valid) {
+            } else if (result.success && !result.valid) {
+                // Cookie 验证通过但未拿到 JWT → 部分成功，可选继续
                 return {
                     valid: false,
                     partialSuccess: true,
                     message: result.message || t('giffgaff.cookie.partialSuccess')
                 };
             } else {
+                // Cookie 验证失败 → 硬错误，不可继续
                 throw new Error(result.message || t('giffgaff.cookie.error'));
             }
         } catch (error) {

--- a/src/giffgaff/js/modules/cookie-handler.js
+++ b/src/giffgaff/js/modules/cookie-handler.js
@@ -38,7 +38,7 @@ export class CookieHandler {
                                 result.accessToken.includes('.') &&
                                 result.accessToken.length > 200;
 
-            if (result.success && result.valid && looksLikeJwt) {
+            if (result.valid && looksLikeJwt) {
                 // 保存访问令牌和Cookie
                 stateManager.set('accessToken', result.accessToken);
                 stateManager.saveCookie(cookie);
@@ -51,7 +51,7 @@ export class CookieHandler {
                     accessToken: result.accessToken,
                     message: t('giffgaff.cookie.verifySuccess')
                 };
-            } else if (result.success && !result.valid) {
+            } else if (!result.valid) {
                 return {
                     valid: false,
                     partialSuccess: true,
@@ -92,7 +92,7 @@ export class CookieHandler {
 
             const result = await response.json();
 
-            if (result && result.success && result.valid) {
+            if (result && result.valid) {
                 // 刷新访问令牌
                 if (result.accessToken) {
                     stateManager.set('accessToken', result.accessToken);

--- a/src/giffgaff/js/modules/oauth-handler.js
+++ b/src/giffgaff/js/modules/oauth-handler.js
@@ -125,7 +125,6 @@ export class OAuthHandler {
                 body: JSON.stringify({
                     code: code,
                     code_verifier: codeVerifier,
-                    redirect_uri: oauthConfig.redirectUri,
                     client_id: oauthConfig.clientId
                 })
             });

--- a/src/js/modules/api-service.js
+++ b/src/js/modules/api-service.js
@@ -64,33 +64,38 @@ class APIService {
    * Execute the actual HTTP request with retry
    */
   async executeRequest(url, options) {
+    const timeout = this.createTimeoutSignal(options.timeout || this.timeout);
     const fetchOptions = {
       method: options.method || 'GET',
       headers: {
         'Content-Type': 'application/json',
         ...options.headers
       },
-      signal: this.createTimeoutSignal(options.timeout || this.timeout)
+      signal: timeout.signal
     };
 
     if (options.body) {
       fetchOptions.body = JSON.stringify(options.body);
     }
 
-    return retry(async () => {
-      const response = await fetch(url, fetchOptions);
+    try {
+      return await retry(async () => {
+        const response = await fetch(url, fetchOptions);
 
-      if (!response.ok) {
-        throw new Error(`HTTP ${response.status}: ${response.statusText}`);
-      }
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
 
-      const contentType = response.headers.get('content-type');
-      if (contentType && contentType.includes('application/json')) {
-        return response.json();
-      }
+        const contentType = response.headers.get('content-type');
+        if (contentType && contentType.includes('application/json')) {
+          return response.json();
+        }
 
-      return response.text();
-    }, this.retries);
+        return response.text();
+      }, this.retries);
+    } finally {
+      timeout.clear();
+    }
   }
 
   /**
@@ -134,8 +139,11 @@ class APIService {
    */
   createTimeoutSignal(timeout) {
     const controller = new AbortController();
-    setTimeout(() => controller.abort(), timeout);
-    return controller.signal;
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
+    return {
+      signal: controller.signal,
+      clear: () => clearTimeout(timeoutId)
+    };
   }
 
   /**

--- a/src/js/modules/api-service.js
+++ b/src/js/modules/api-service.js
@@ -64,23 +64,26 @@ class APIService {
    * Execute the actual HTTP request with retry
    */
   async executeRequest(url, options) {
-    const timeout = this.createTimeoutSignal(options.timeout || this.timeout);
     const fetchOptions = {
       method: options.method || 'GET',
       headers: {
         'Content-Type': 'application/json',
         ...options.headers
       },
-      signal: timeout.signal
     };
 
     if (options.body) {
       fetchOptions.body = JSON.stringify(options.body);
     }
 
-    try {
-      return await retry(async () => {
-        const response = await fetch(url, fetchOptions);
+    return await retry(async () => {
+      const timeout = this.createTimeoutSignal(options.timeout || this.timeout);
+      try {
+        const requestOptions = {
+          ...fetchOptions,
+          signal: timeout.signal
+        };
+        const response = await fetch(url, requestOptions);
 
         if (!response.ok) {
           throw new Error(`HTTP ${response.status}: ${response.statusText}`);
@@ -92,10 +95,10 @@ class APIService {
         }
 
         return response.text();
-      }, this.retries);
-    } finally {
-      timeout.clear();
-    }
+      } finally {
+        timeout.clear();
+      }
+    }, this.retries);
   }
 
   /**

--- a/tests/modules/api-service.test.js
+++ b/tests/modules/api-service.test.js
@@ -103,6 +103,31 @@ describe('APIService', () => {
   });
 
   describe('错误处理', () => {
+
+
+    it('应该为每次重试创建新的超时信号', async () => {
+      const timeoutService = new APIService({ baseURL: 'https://api.test.com', timeout: 5000, retries: 2 });
+      const firstSignal = { aborted: true };
+      const secondSignal = { aborted: false };
+      const createTimeoutSpy = jest.spyOn(timeoutService, 'createTimeoutSignal')
+        .mockReturnValueOnce({ signal: firstSignal, clear: jest.fn() })
+        .mockReturnValueOnce({ signal: secondSignal, clear: jest.fn() });
+
+      fetch.mockImplementationOnce(() => Promise.reject(new Error('timeout')));
+      fetch.mockResolvedValueOnce({
+        ok: true,
+        headers: { get: () => 'application/json' },
+        json: () => Promise.resolve({ ok: true })
+      });
+
+      const result = await timeoutService.get('/retry-timeout');
+
+      expect(result).toEqual({ ok: true });
+      expect(fetch).toHaveBeenCalledTimes(2);
+      expect(createTimeoutSpy).toHaveBeenCalledTimes(2);
+      expect(fetch.mock.calls[0][1].signal).toBe(firstSignal);
+      expect(fetch.mock.calls[1][1].signal).toBe(secondSignal);
+    });
     it('应该在 HTTP 错误时抛出异常', async () => {
       // mock fetch 返回 error response，但重试会多次调用
       fetch.mockResolvedValue({

--- a/tests/security/bff-proxy.test.js
+++ b/tests/security/bff-proxy.test.js
@@ -3,6 +3,7 @@ describe('BFF proxy guardrails', () => {
   const OriginalRequest = global.Request;
   const OriginalResponse = global.Response;
   const OriginalDeno = global.Deno;
+  const OriginalFetch = global.fetch;
 
   class MockHeaders {
     constructor(init = {}) {
@@ -92,6 +93,7 @@ describe('BFF proxy guardrails', () => {
     jest.restoreAllMocks();
     global.Request = OriginalRequest;
     global.Response = OriginalResponse;
+    global.fetch = OriginalFetch;
     global.Deno = OriginalDeno;
   });
 
@@ -106,7 +108,21 @@ describe('BFF proxy guardrails', () => {
     expect(response.status).toBe(404);
   });
 
-  it('blocks missing-origin calls to protected BFF targets', async () => {
+
+
+  it('allows same-origin public GET requests without Origin', async () => {
+    const mod = await import('../../netlify/edge-functions/bff-proxy.js');
+    const request = new Request('https://example.com/bff/public-config', {
+      method: 'GET'
+    });
+
+    const response = await mod.default(request);
+
+    expect(response.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns 403 for missing-origin protected POST requests', async () => {
     const mod = await import('../../netlify/edge-functions/bff-proxy.js');
     const request = new Request('https://example.com/bff/verify-cookie', {
       method: 'POST',
@@ -115,7 +131,9 @@ describe('BFF proxy guardrails', () => {
     });
 
     const response = await mod.default(request);
+
     expect(response.status).toBe(403);
+    expect(response.headers.get('access-control-allow-origin')).toBe('https://esim.cosr.eu.org');
   });
 
   it('forwards allowlisted BFF targets with the server x-esim-key', async () => {

--- a/tests/security/bff-proxy.test.js
+++ b/tests/security/bff-proxy.test.js
@@ -1,0 +1,146 @@
+describe('BFF proxy guardrails', () => {
+  const originalEnv = process.env;
+  const OriginalRequest = global.Request;
+  const OriginalResponse = global.Response;
+  const OriginalDeno = global.Deno;
+
+  class MockHeaders {
+    constructor(init = {}) {
+      this.map = new Map();
+      if (init && typeof init.entries === 'function') {
+        Array.from(init.entries()).forEach(([key, value]) => {
+          this.set(key, value);
+        });
+      } else {
+        Object.entries(init).forEach(([key, value]) => {
+          this.set(key, value);
+        });
+      }
+    }
+
+    get(name) {
+      return this.map.get(String(name).toLowerCase()) || null;
+    }
+
+    set(name, value) {
+      this.map.set(String(name).toLowerCase(), String(value));
+    }
+
+    delete(name) {
+      this.map.delete(String(name).toLowerCase());
+    }
+
+    entries() {
+      return this.map.entries();
+    }
+
+    [Symbol.iterator]() {
+      return this.map[Symbol.iterator]();
+    }
+  }
+
+  class MockRequest {
+    constructor(url, init = {}) {
+      this.url = url;
+      this.method = init.method || 'GET';
+      this.headers = init.headers instanceof MockHeaders ? init.headers : new MockHeaders(init.headers || {});
+      this.body = init.body;
+    }
+
+    async arrayBuffer() {
+      const text = typeof this.body === 'string' ? this.body : JSON.stringify(this.body || '');
+      return new TextEncoder().encode(text).buffer;
+    }
+  }
+
+  class MockResponse {
+    constructor(body = '', init = {}) {
+      this.body = body;
+      this.status = init.status || 200;
+      this.statusText = init.statusText || '';
+      this.headers = init.headers instanceof MockHeaders ? init.headers : new MockHeaders(init.headers || {});
+    }
+
+    async text() {
+      return typeof this.body === 'string' ? this.body : JSON.stringify(this.body);
+    }
+  }
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      ACCESS_KEY: 'test-access-key',
+      ALLOWED_ORIGIN: 'https://esim.cosr.eu.org'
+    };
+    global.Deno = {
+      env: {
+        get: (name) => {
+          if (name === 'ACCESS_KEY') return 'test-access-key';
+          if (name === 'ALLOWED_ORIGIN') return 'https://esim.cosr.eu.org';
+          return '';
+        }
+      }
+    };
+    global.Request = MockRequest;
+    global.Response = MockResponse;
+    global.fetch = jest.fn().mockResolvedValue(new MockResponse('ok', { status: 200, headers: { 'content-type': 'text/plain' } }));
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+    global.Request = OriginalRequest;
+    global.Response = OriginalResponse;
+    global.Deno = OriginalDeno;
+  });
+
+  it('blocks unknown BFF targets', async () => {
+    const mod = await import('../../netlify/edge-functions/bff-proxy.js');
+    const request = new Request('https://example.com/bff/unknown-route', {
+      method: 'POST',
+      headers: { origin: 'https://esim.cosr.eu.org' }
+    });
+
+    const response = await mod.default(request);
+    expect(response.status).toBe(404);
+  });
+
+  it('blocks missing-origin calls to protected BFF targets', async () => {
+    const mod = await import('../../netlify/edge-functions/bff-proxy.js');
+    const request = new Request('https://example.com/bff/verify-cookie', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ cookie: 'test-cookie' })
+    });
+
+    const response = await mod.default(request);
+    expect(response.status).toBe(403);
+  });
+
+  it('forwards allowlisted BFF targets with the server x-esim-key', async () => {
+    const mod = await import('../../netlify/edge-functions/bff-proxy.js');
+    const request = new Request('https://example.com/bff/giffgaff-token-exchange', {
+      method: 'POST',
+      headers: {
+        origin: 'https://esim.cosr.eu.org',
+        'content-type': 'application/json',
+        'x-esim-key': 'client-key',
+        'x-app-key': 'client-app-key'
+      },
+      body: JSON.stringify({
+        code: 'authorization-code',
+        code_verifier: 'a'.repeat(64)
+      })
+    });
+
+    const response = await mod.default(request);
+
+    expect(response.status).toBe(200);
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    const proxiedRequest = global.fetch.mock.calls[0][0];
+    expect(proxiedRequest.url).toBe('https://example.com/.netlify/functions/giffgaff-token-exchange');
+    expect(proxiedRequest.headers.get('x-esim-key')).toBe('test-access-key');
+    expect(proxiedRequest.headers.get('x-app-key')).toBeNull();
+  });
+});

--- a/tests/security/functions-auth.test.js
+++ b/tests/security/functions-auth.test.js
@@ -49,6 +49,32 @@ describe('Functions authentication hardening', () => {
     expect(result.authorized).toBe(true);
   });
 
+
+  it('allows OPTIONS preflight for allowed origin', () => {
+    const { middleware } = loadModules();
+
+    const result = middleware.authenticate({
+      httpMethod: 'OPTIONS',
+      headers: { origin: 'https://esim.cosr.eu.org' },
+      body: '{}',
+      queryStringParameters: {}
+    });
+
+    expect(result.preflight).toBe(true);
+    expect(result.origin).toBe('https://esim.cosr.eu.org');
+  });
+
+  it('rejects OPTIONS preflight for disallowed origin', () => {
+    const { middleware } = loadModules();
+
+    expect(() => middleware.authenticate({
+      httpMethod: 'OPTIONS',
+      headers: { origin: 'https://evil.example.com' },
+      body: '{}',
+      queryStringParameters: {}
+    })).toThrow('Origin not allowed');
+  });
+
   it('does not accept authKey from query or body', () => {
     const { middleware } = loadModules();
     const event = {
@@ -85,6 +111,27 @@ describe('Functions authentication hardening', () => {
     const form = axios.post.mock.calls[0][1];
     expect(form).toContain('redirect_uri=giffgaff%3A%2F%2Fauth%2Fcallback%2F');
     expect(form).not.toContain('attacker.example');
+  });
+
+
+
+  it('throws a configuration error when ACCESS_KEY is missing for token exchange', async () => {
+    const { tokenExchange } = loadModules({ ACCESS_KEY: '' });
+
+    const result = await tokenExchange.handler({
+      httpMethod: 'POST',
+      headers: {
+        origin: 'https://esim.cosr.eu.org'
+      },
+      body: JSON.stringify({
+        code: 'authorization-code',
+        code_verifier: 'a'.repeat(64)
+      }),
+      queryStringParameters: {}
+    }, { functionName: 'giffgaff-token-exchange' });
+
+    expect(result.statusCode).toBe(500);
+    expect(result.body).toContain('ACCESS_KEY');
   });
 
   it('uses configured GIFFGAFF_REDIRECT_URI for token exchange', async () => {

--- a/tests/security/functions-auth.test.js
+++ b/tests/security/functions-auth.test.js
@@ -1,0 +1,115 @@
+describe('Functions authentication hardening', () => {
+  const originalEnv = process.env;
+
+  function loadModules(envOverrides = {}) {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      ACCESS_KEY: 'test-access-key',
+      ALLOWED_ORIGIN: 'https://esim.cosr.eu.org',
+      GIFFGAFF_CLIENT_ID: 'client-id',
+      GIFFGAFF_CLIENT_SECRET: 'abcdefghijklmnopqrstuvwxyzABCDEF',
+      GIFFGAFF_REDIRECT_URI: 'giffgaff://auth/callback/',
+      ...envOverrides
+    };
+
+    return {
+      axios: require('axios'),
+      middleware: require('../../netlify/functions/_shared/middleware'),
+      tokenExchange: require('../../netlify/functions/giffgaff-token-exchange')
+    };
+  }
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('rejects protected browserless calls without internal key', () => {
+    const { middleware } = loadModules();
+
+    expect(() => middleware.authenticate({
+      httpMethod: 'POST',
+      headers: {},
+      body: '{}',
+      queryStringParameters: {}
+    })).toThrow('Origin not allowed');
+  });
+
+  it('allows protected browserless internal calls with x-esim-key', () => {
+    const { middleware } = loadModules();
+
+    const result = middleware.authenticate({
+      httpMethod: 'POST',
+      headers: { 'x-esim-key': 'test-access-key' },
+      body: '{}',
+      queryStringParameters: {}
+    });
+
+    expect(result.authorized).toBe(true);
+  });
+
+  it('does not accept authKey from query or body', () => {
+    const { middleware } = loadModules();
+    const event = {
+      httpMethod: 'POST',
+      headers: { origin: 'https://esim.cosr.eu.org' },
+      body: JSON.stringify({ authKey: 'test-access-key' }),
+      queryStringParameters: { authKey: 'test-access-key' }
+    };
+
+    expect(() => middleware.authenticate(event)).toThrow('Unauthorized');
+  });
+
+  it('uses server redirect URI for token exchange even if client sends another value', async () => {
+    const { axios, tokenExchange } = loadModules();
+    jest.spyOn(axios, 'post').mockResolvedValue({
+      data: { access_token: 'token' }
+    });
+
+    const result = await tokenExchange.handler({
+      httpMethod: 'POST',
+      headers: {
+        origin: 'https://esim.cosr.eu.org',
+        'x-esim-key': 'test-access-key'
+      },
+      body: JSON.stringify({
+        code: 'authorization-code',
+        code_verifier: 'a'.repeat(64),
+        redirect_uri: 'https://attacker.example/callback'
+      }),
+      queryStringParameters: {}
+    }, { functionName: 'giffgaff-token-exchange' });
+
+    expect(result.statusCode).toBe(200);
+    const form = axios.post.mock.calls[0][1];
+    expect(form).toContain('redirect_uri=giffgaff%3A%2F%2Fauth%2Fcallback%2F');
+    expect(form).not.toContain('attacker.example');
+  });
+
+  it('uses configured GIFFGAFF_REDIRECT_URI for token exchange', async () => {
+    const { axios, tokenExchange } = loadModules({
+      GIFFGAFF_REDIRECT_URI: 'giffgaff://custom/callback/'
+    });
+    jest.spyOn(axios, 'post').mockResolvedValue({
+      data: { access_token: 'token' }
+    });
+
+    const result = await tokenExchange.handler({
+      httpMethod: 'POST',
+      headers: {
+        origin: 'https://esim.cosr.eu.org',
+        'x-esim-key': 'test-access-key'
+      },
+      body: JSON.stringify({
+        code: 'authorization-code',
+        code_verifier: 'a'.repeat(64)
+      }),
+      queryStringParameters: {}
+    }, { functionName: 'giffgaff-token-exchange' });
+
+    expect(result.statusCode).toBe(200);
+    const form = axios.post.mock.calls[0][1];
+    expect(form).toContain('redirect_uri=giffgaff%3A%2F%2Fcustom%2Fcallback%2F');
+  });
+});

--- a/tests/security/server-routes.test.js
+++ b/tests/security/server-routes.test.js
@@ -1,0 +1,38 @@
+jest.mock('cheerio', () => ({
+  load: () => ({})
+}));
+
+describe('Local server route coverage', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = {
+      ...originalEnv,
+      ACCESS_KEY: 'test-access-key',
+      ALLOWED_ORIGIN: 'https://esim.cosr.eu.org',
+      SIMYO_CLIENT_TOKEN: 'test-simyo-token'
+    };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('exposes the same BFF targets locally as the production allowlist', () => {
+    const app = require('../../server.js');
+    const routes = app.locals.bffRoutes;
+
+    expect(routes).toEqual(expect.arrayContaining([
+      '/bff/giffgaff-token-exchange',
+      '/bff/giffgaff-graphql',
+      '/bff/giffgaff-mfa-challenge',
+      '/bff/giffgaff-mfa-validation',
+      '/bff/giffgaff-sms-activate',
+      '/bff/auto-activate-esim',
+      '/bff/verify-cookie',
+      '/bff/public-config'
+    ]));
+  });
+});

--- a/tests/security/server-routes.test.js
+++ b/tests/security/server-routes.test.js
@@ -24,7 +24,7 @@ describe('Local server route coverage', () => {
     const app = require('../../server.js');
     const routes = app.locals.bffRoutes;
 
-    expect(routes).toEqual(expect.arrayContaining([
+    const expectedRoutes = [
       '/bff/giffgaff-token-exchange',
       '/bff/giffgaff-graphql',
       '/bff/giffgaff-mfa-challenge',
@@ -33,6 +33,8 @@ describe('Local server route coverage', () => {
       '/bff/auto-activate-esim',
       '/bff/verify-cookie',
       '/bff/public-config'
-    ]));
+    ];
+
+    expect([...routes].sort()).toEqual([...expectedRoutes].sort());
   });
 });


### PR DESCRIPTION
## Summary by Sourcery

Harden authentication around BFF proxying and internal Netlify function calls while aligning local server routing with the production allowlist.

Bug Fixes:
- Ensure verify-cookie consistently reports invalid cookies via the valid flag and update cookie handling logic to rely on it instead of the success flag.
- Fix APIService timeout handling to clear abort timers after requests complete.

Enhancements:
- Restrict BFF proxying to an explicit allowlist with stricter method, origin, and CORS validation, and ensure server-injected x-esim-key overrides any client-supplied internal keys.
- Enforce internal Netlify function calls to use server-provided x-esim-key headers only, removing deprecated authKey query/body fallbacks.
- Move Giffgaff token exchange redirect_uri to server-side configuration and document the behavior for OAuth flows.
- Update Simyo API forwarding to always use server-configured client token rather than values supplied by clients.
- Adjust local Express server startup to support requiring server.js without binding a port and expose route metadata for tests.

Documentation:
- Expand CLAUDE documentation for functions and edge proxy to cover internal call constraints, environment variables, and Giffgaff redirect URI behavior.
- Update AI usage guidelines to prefer the new fast_context search tool and clarify Giffgaff OAuth redirect URI responsibilities.

Tests:
- Add security-focused tests for BFF proxy guardrails, functions authentication behavior, token exchange redirect URI usage, and local server route coverage.

## Summary by Sourcery

Harden BFF proxy and Netlify function authentication, aligning routing and auth semantics between edge, functions, frontend, and local server while tightening token and cookie handling.

Bug Fixes:
- Fix APIService timeout handling to use per-attempt abort controllers and clear timers after completion.
- Align verify-cookie responses and downstream consumers to rely on a consistent valid flag for cookie usability.

Enhancements:
- Restrict BFF proxying to an explicit allowlist with stricter method, origin, and CORS validation and enforce server-owned x-esim-key headers for internal calls.
- Enforce internal Netlify function calls to authenticate only via server-provided headers, removing authKey query/body usage and centralizing internal header construction.
- Move Giffgaff token exchange redirect URIs and Simyo client credentials to server-side configuration, ignoring client-provided redirect_uri and tokens.
- Expose local server BFF and function route metadata for tests and make server startup conditional so it can be required without binding a port.

Documentation:
- Document internal function call constraints, required environment variables, and Giffgaff token exchange redirect URI behavior for functions and edge proxy.
- Update AI usage guidelines to prefer the new fast_context search tool and clarify separation of frontend and server redirect URI responsibilities.

Tests:
- Add security-focused tests for BFF proxy routing/CORS guardrails, hardened functions authentication, and alignment of local server routes with the production allowlist.
- Add APIService timeout retry tests to verify per-attempt abort signals and behavior.