### PR TITLE
🐛 fix: 增强钱包扩展冲突检测 [skip ci]

### DIFF
--- a/src/js/modules/sentry-init.js
+++ b/src/js/modules/sentry-init.js
@@ -201,19 +201,41 @@ if (typeof window !== 'undefined') {
 
     let message = '';
     let stack = '';
+    let allReasonText = '';
 
     if (typeof reason === 'string') {
       message = reason;
+      allReasonText = reason;
     } else if (reason && typeof reason === 'object') {
       message = reason.message || reason.toString();
       stack = reason.stack || '';
+      // 收集 reason 对象的所有属性值，用于检测钱包扩展冲突
+      // 钱包扩展可能 reject {code: 4001, message: "wallet must has at least one account"} 这样的对象
+      const reasonValues = [];
+      try {
+        Object.keys(reason).forEach(key => {
+          const val = reason[key];
+          if (val !== null && val !== undefined) {
+            reasonValues.push(String(val));
+          }
+        });
+      } catch (e) {
+        // 忽略遍历错误
+      }
+      allReasonText = reasonValues.join(' ');
     }
 
+    // 检查 message 和 reason 对象的所有属性值是否包含扩展关键词
     let shouldBlock = isExtensionProviderConflict({
       message,
       stack,
       mechanismType: 'onunhandledrejection',
     });
+
+    // 额外检查 reason 对象的所有属性值
+    if (!shouldBlock && allReasonText) {
+      shouldBlock = includesExtensionKeyword(allReasonText);
+    }
 
     if (!shouldBlock && event.promise) {
       shouldBlock = includesExtensionKeyword(event.promise);

--- a/src/js/sentry-loader.js
+++ b/src/js/sentry-loader.js
@@ -249,19 +249,42 @@
     var reason = event && event.reason;
     var message = '';
     var stack = '';
+    var allReasonText = '';
 
     if (typeof reason === 'string') {
       message = reason;
+      allReasonText = reason;
     } else if (reason && typeof reason === 'object') {
       message = reason.message || reason.toString();
       stack = reason.stack || '';
+      // 收集 reason 对象的所有属性值，用于检测钱包扩展冲突
+      // 钱包扩展可能 reject {code: 4001, message: "wallet must has at least one account"} 这样的对象
+      var reasonValues = [];
+      try {
+        var keys = Object.keys(reason);
+        for (var i = 0; i < keys.length; i++) {
+          var val = reason[keys[i]];
+          if (val !== null && val !== undefined) {
+            reasonValues.push(String(val));
+          }
+        }
+      } catch (e) {
+        // 忽略遍历错误
+      }
+      allReasonText = reasonValues.join(' ');
     }
 
+    // 检查 message 和 reason 对象的所有属性值是否包含扩展关键词
     var shouldBlock = isExtensionProviderConflict({
       message: message,
       stack: stack,
       mechanismType: 'onunhandledrejection'
     });
+
+    // 额外检查 reason 对象的所有属性值
+    if (!shouldBlock && allReasonText) {
+      shouldBlock = includesExtensionKeyword(allReasonText);
+    }
 
     if (!shouldBlock && event && event.promise) {
       shouldBlock = includesExtensionKeyword(event.promise);


### PR DESCRIPTION
[skip ci]

## 问题
用户安装钱包扩展（如 MetaMask、TronLink）后访问 Giffgaff 页面，扩展会注入代码并创建 Promise，reject 对象如 `{code: 4001, message: 'wallet must has at least one account'}`，导致 Sentry 上报大量噪音错误。

## 修复
在全局 `unhandledrejection` 事件监听器中，除了检查 `message` 字段外，新增对 `reason` 对象所有属性值的扫描，确保能匹配到扩展关键词。

## 修改文件
- `src/js/modules/sentry-init.js`
- `src/js/sentry-loader.js`

## 测试
- Node.js 语法验证通过
- 这是 Sentry 过滤器增强，无需功能测试

## Summary by Sourcery

Bug Fixes:
- Extend unhandledrejection handling to scan all properties of the rejection reason object for wallet extension signatures, reducing noise from extension-related errors in Sentry.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
增强全局 unhandledrejection 的钱包扩展冲突检测，扫描 reason 对象的所有属性值以识别 MetaMask/TronLink 等注入错误。减少钱包扩展导致的 Sentry 噪音上报。

- **Bug Fixes**
  - 拼接 reason 所有属性值并执行 includesExtensionKeyword 检测
  - 保留对 message/stack 与 event.promise 的既有检查
  - 属性遍历加 try-catch，避免不可遍历对象引发二次异常

<sup>Written for commit 95650fa02a0a16ce4ec197b643e2c7146c75792d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/Silentely/eSIM-Tools/pull/71?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

